### PR TITLE
add paths to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 .idea/
 caladrius.iml
 
+# graph path dump json dir
+paths/
+


### PR DESCRIPTION
add ./paths to ignore. the ./paths dir is required for graph db path dump. but the files in ./paths should not included in the git